### PR TITLE
Fix error on default configuration

### DIFF
--- a/src/connectionResolver.js
+++ b/src/connectionResolver.js
@@ -142,7 +142,7 @@ export function prepareConnectionResolver(
       ...additionalArgs,
       sort: {
         type: sortEnumType,
-        defaultValue: sortEnumType.getValues()[0].value,
+        defaultValue: sortEnumType.getValues()[0].name,
         description: 'Sort argument for data ordering',
       },
     },


### PR DESCRIPTION
When using graphql-compose-mongoose with the default configuration, it throws this error
```
Variable \"$_v1_sort\" got invalid value {\"_id\":-1}; Expected type SortConnectionXXXXXXEnum.
```
This fixed it. It is the Enum type so the default value should be the name of the value, right?
Best,