### PR TITLE
feat: Add option to specify connectionResolverName

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ import composeWithConnection from 'graphql-compose-connection';
 import userTypeComposer from './user.js';
 
 composeWithConnection(userTypeComposer, {
+  connectionResolverName: 'connection', // Default
   findResolverName: 'findMany',
   countResolverName: 'count',
   sort: {

--- a/src/__tests__/composeWithConnection-test.js
+++ b/src/__tests__/composeWithConnection-test.js
@@ -50,6 +50,53 @@ describe('composeWithRelay', () => {
       expect(myTC.getResolver('connection')).toBeTruthy();
       expect(myTC.getResolver('connection').resolve()).toBe('mockData');
     });
+
+    it('should add resolver with user-specified name', () => {
+      let myTC = TypeComposer.create('type CustomComplex { a: String, b: Int }');
+      myTC.addResolver({
+        name: 'count',
+        resolve: () => 1,
+      });
+      myTC.addResolver({
+        name: 'findMany',
+        resolve: () => ['mockData'],
+      });
+      myTC = composeWithConnection(myTC, {
+        connectionResolverName: 'customConnection',
+        countResolverName: 'count',
+        findResolverName: 'findMany',
+        sort: sortOptions,
+      });
+
+      expect(myTC.getResolver('customConnection')).toBeTruthy();
+      expect(myTC.hasResolver('connection')).toBeFalsy();
+    });
+
+    it('should add two connection resolvers', () => {
+      let myTC = TypeComposer.create('type CustomComplex { a: String, b: Int }');
+      myTC.addResolver({
+        name: 'count',
+        resolve: () => 1,
+      });
+      myTC.addResolver({
+        name: 'findMany',
+        resolve: () => ['mockData'],
+      });
+      myTC = composeWithConnection(myTC, {
+        countResolverName: 'count',
+        findResolverName: 'findMany',
+        sort: sortOptions,
+      });
+      myTC = composeWithConnection(myTC, {
+        connectionResolverName: 'customConnection',
+        countResolverName: 'count',
+        findResolverName: 'findMany',
+        sort: sortOptions,
+      });
+
+      expect(myTC.hasResolver('connection')).toBeTruthy();
+      expect(myTC.getResolver('customConnection')).toBeTruthy();
+    });
   });
 
   describe('check `connection` resolver props', () => {

--- a/src/composeWithConnection.js
+++ b/src/composeWithConnection.js
@@ -3,6 +3,7 @@
 import { TypeComposer } from 'graphql-compose';
 import { prepareConnectionResolver } from './connectionResolver';
 import type { ComposeWithConnectionOpts } from './connectionResolver';
+import { resolverName } from './utils/name';
 
 export function composeWithConnection(
   typeComposer: TypeComposer,
@@ -16,12 +17,12 @@ export function composeWithConnection(
     throw new Error('You should provide non-empty options to composeWithConnection');
   }
 
-  if (typeComposer.hasResolver('connection')) {
+  if (typeComposer.hasResolver(resolverName(opts.connectionResolverName))) {
     return typeComposer;
   }
 
   const resolver = prepareConnectionResolver(typeComposer, opts);
 
-  typeComposer.setResolver('connection', resolver);
+  typeComposer.setResolver(resolverName(opts.connectionResolverName), resolver);
   return typeComposer;
 }

--- a/src/connectionResolver.js
+++ b/src/connectionResolver.js
@@ -12,8 +12,10 @@ import type { GraphQLResolveInfo } from 'graphql-compose/lib/graphql';
 import { prepareConnectionType } from './types/connectionType';
 import { prepareSortType } from './types/sortInputType';
 import { cursorToData, dataToCursor, type CursorDataType } from './cursor';
+import { resolverName } from './utils/name';
 
 export type ComposeWithConnectionOpts = {
+  connectionResolverName?: string,
   findResolverName: string,
   countResolverName: string,
   sort: ConnectionSortMapOpts,
@@ -125,8 +127,8 @@ export function prepareConnectionResolver(
   const sortEnumType = prepareSortType(tc, opts);
 
   return new tc.constructor.schemaComposer.Resolver({
-    type: prepareConnectionType(tc),
-    name: 'connection',
+    type: prepareConnectionType(tc, opts.connectionResolverName),
+    name: resolverName(opts.connectionResolverName),
     kind: 'query',
     args: {
       first: {

--- a/src/types/__tests__/connectionType-test.js
+++ b/src/types/__tests__/connectionType-test.js
@@ -55,8 +55,29 @@ describe('types/connectionType.js', () => {
       expect(prepareConnectionType(userTypeComposer)).toBeInstanceOf(GraphQLObjectType);
     });
 
+    it('should return the same GraphQLObjectType object when called again', () => {
+      const firstConnectionType = prepareConnectionType(userTypeComposer);
+      const secondConnectionType = prepareConnectionType(userTypeComposer);
+      expect(firstConnectionType).toBeInstanceOf(GraphQLObjectType);
+      expect(firstConnectionType).toBe(secondConnectionType);
+    });
+
+    it('should return a separate GraphQLObjectType with a different name', () => {
+      const connectionType = prepareConnectionType(userTypeComposer);
+      const otherConnectionType = prepareConnectionType(userTypeComposer, 'otherConnection');
+      expect(connectionType).toBeInstanceOf(GraphQLObjectType);
+      expect(otherConnectionType).toBeInstanceOf(GraphQLObjectType);
+      expect(connectionType).not.toBe(otherConnectionType);
+    });
+
     it('should have name ending with `Connection`', () => {
       expect(prepareConnectionType(userTypeComposer).name).toBe('UserConnection');
+    });
+
+    it('should have name ending with `OtherConnection` when passed lowercase otherConnection', () => {
+      expect(prepareConnectionType(userTypeComposer, 'otherConnection').name).toBe(
+        'UserOtherConnection'
+      );
     });
 
     it('should have field `count` with provided Type', () => {

--- a/src/types/__tests__/sortInputType-test.js
+++ b/src/types/__tests__/sortInputType-test.js
@@ -141,6 +141,23 @@ describe('types/sortInputType.js', () => {
       expect(sortType.name).toBe('SortConnectionUserEnum');
     });
 
+    it('should have name `Sort[resolverName][typeName]Enum`', () => {
+      const otherSortType = prepareSortType(userTypeComposer, {
+        sort: {
+          _ID_ASC: {
+            value: { id: 1 },
+            cursorFields: ['id'],
+            beforeCursorQuery: () => {},
+            afterCursorQuery: () => {},
+          },
+        },
+        findResolverName: 'finMany',
+        countResolverName: 'count',
+        connectionResolverName: 'otherConnection',
+      });
+      expect(otherSortType.name).toBe('SortOtherConnectionUserEnum');
+    });
+
     it('should have enum values', () => {
       const etc = EnumTypeComposer.create(sortType);
       expect(etc.hasField('_ID_ASC')).toBeTruthy();

--- a/src/types/sortInputType.js
+++ b/src/types/sortInputType.js
@@ -4,6 +4,7 @@
 import { TypeComposer } from 'graphql-compose';
 import { GraphQLEnumType } from 'graphql-compose/lib/graphql';
 import { isFunction } from '../utils/is';
+import { typeName as uppercaseTypeName } from '../utils/name';
 import type { ConnectionSortOpts, ComposeWithConnectionOpts } from '../connectionResolver';
 
 export function prepareSortType(
@@ -14,7 +15,9 @@ export function prepareSortType(
     throw new Error('Option `sort` should not be empty in composeWithConnection');
   }
 
-  const typeName = `SortConnection${typeComposer.getTypeName()}Enum`;
+  const typeName = `Sort${uppercaseTypeName(
+    opts.connectionResolverName
+  )}${typeComposer.getTypeName()}Enum`;
 
   const sortKeys = Object.keys(opts.sort);
   if (sortKeys.length === 0) {

--- a/src/utils/name.js
+++ b/src/utils/name.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+export function resolverName(name: ?string) {
+  return name || 'connection';
+}
+
+export function typeName(name: ?string) {
+  const lowercaseName = resolverName(name);
+  return lowercaseName[0].toUpperCase() + lowercaseName.slice(1);
+}


### PR DESCRIPTION
Followup to #35.

Add `connectionResolverName` option. This also gets used to create the types.

Because it now needs to cache more connectionTypes, based on the name, i had to add an extra layer for that which couldn't use a WeakMap.