### PR TITLE
Support edges with fields

### DIFF
--- a/src/__tests__/__snapshots__/connectionResolver-test.js.snap
+++ b/src/__tests__/__snapshots__/connectionResolver-test.js.snap
@@ -4,6 +4,73 @@ exports[`connectionResolver "Relay Cursor Connections Specification (Pagination 
 
 exports[`connectionResolver "Relay Cursor Connections Specification (Pagination algorithm)": ApplyCursorsToEdges(allEdges, before, after): should throw error if \`last\` is less than 0 1`] = `[Error: Argument \`last\` should be non-negative number.]`;
 
+exports[`connectionResolver edges with data correctly handles filtering 1`] = `
+Object {
+  "count": 1,
+  "edges": Array [
+    Object {
+      "cursor": "MA==",
+      "id": 1,
+      "node": Object {
+        "age": 12,
+        "gender": "m",
+        "id": 2,
+        "name": "user02",
+      },
+      "otherUserId": 2,
+      "type": "likes",
+      "userId": 1,
+    },
+  ],
+  "pageInfo": Object {
+    "endCursor": "MA==",
+    "hasNextPage": false,
+    "hasPreviousPage": false,
+    "startCursor": "MA==",
+  },
+}
+`;
+
+exports[`connectionResolver edges with data correctly resolves with edges 1`] = `
+Object {
+  "count": 2,
+  "edges": Array [
+    Object {
+      "cursor": "MA==",
+      "id": 1,
+      "node": Object {
+        "age": 12,
+        "gender": "m",
+        "id": 2,
+        "name": "user02",
+      },
+      "otherUserId": 2,
+      "type": "likes",
+      "userId": 1,
+    },
+    Object {
+      "cursor": "MQ==",
+      "id": 2,
+      "node": Object {
+        "age": 11,
+        "gender": "m",
+        "id": 1,
+        "name": "user01",
+      },
+      "otherUserId": 1,
+      "type": "dislikes",
+      "userId": 2,
+    },
+  ],
+  "pageInfo": Object {
+    "endCursor": "MQ==",
+    "hasNextPage": false,
+    "hasPreviousPage": false,
+    "startCursor": "MA==",
+  },
+}
+`;
+
 exports[`connectionResolver fallback logic (offset in cursor) should throw error if \`first\` is less than 0 1`] = `[Error: Argument \`first\` should be non-negative number.]`;
 
 exports[`connectionResolver fallback logic (offset in cursor) should throw error if \`last\` is less than 0 1`] = `[Error: Argument \`last\` should be non-negative number.]`;

--- a/src/__tests__/connectionResolver-test.js
+++ b/src/__tests__/connectionResolver-test.js
@@ -3,7 +3,7 @@
 
 import { Resolver } from 'graphql-compose';
 import { GraphQLInt, GraphQLString } from 'graphql-compose/lib/graphql';
-import { userTC, userList, sortOptions } from '../__mocks__/userTC';
+import { userTC, userLinkTC, userList, sortOptions } from '../__mocks__/userTC';
 import { dataToCursor } from '../cursor';
 import { prepareConnectionResolver, prepareRawQuery, preparePageInfo } from '../connectionResolver';
 
@@ -827,6 +827,32 @@ describe('connectionResolver', () => {
       expect(data.edges.length).toBe(5);
       expect(data.pageInfo.hasNextPage).toBe(true);
       expect(data.pageInfo.hasPreviousPage).toBe(true);
+    });
+  });
+
+  describe('edges with data', () => {
+    const edgeDataResolver = prepareConnectionResolver(userTC, {
+      countResolverName: 'countThroughLink',
+      findResolverName: 'findManyThroughLink',
+      sort: sortOptions,
+      defaultLimit: 5,
+      edgeFields: userLinkTC.getFields(),
+    });
+    it('correctly resolves with edges', async () => {
+      const data = await edgeDataResolver.resolve({
+        args: {},
+        projection: { count: true, edges: true },
+      });
+      expect(data.edges.length).toBe(2);
+      expect(data).toMatchSnapshot();
+    });
+    it('correctly handles filtering', async () => {
+      const data = await edgeDataResolver.resolve({
+        args: { filter: { edge: { type: 'likes' } } },
+        projection: { count: true, edges: true },
+      });
+      expect(data.edges.length).toBe(1);
+      expect(data).toMatchSnapshot();
     });
   });
 });

--- a/src/composeWithConnection.js
+++ b/src/composeWithConnection.js
@@ -6,7 +6,7 @@ import type { ComposeWithConnectionOpts } from './connectionResolver';
 
 export function composeWithConnection<TSource, TContext>(
   typeComposer: ObjectTypeComposer<TSource, TContext>,
-  opts: ComposeWithConnectionOpts
+  opts: ComposeWithConnectionOpts<TContext>
 ): ObjectTypeComposer<TSource, TContext> {
   if (!(typeComposer instanceof ObjectTypeComposer)) {
     throw new Error('You should provide ObjectTypeComposer instance to composeWithRelay method');

--- a/src/types/connectionType.js
+++ b/src/types/connectionType.js
@@ -7,6 +7,7 @@ import {
   NonNullComposer,
   upperFirst,
   type SchemaComposer,
+  type ObjectTypeComposerFieldConfigMap,
 } from 'graphql-compose';
 
 // This is required due compatibility with old client code bases
@@ -47,20 +48,22 @@ export function preparePageInfoType(
 }
 
 export function prepareEdgeType<TContext>(
-  typeComposer: ObjectTypeComposer<any, TContext>
+  nodeTypeComposer: ObjectTypeComposer<any, TContext>,
+  edgeFields?: ObjectTypeComposerFieldConfigMap<any, TContext>
 ): ObjectTypeComposer<any, TContext> {
-  const name = `${typeComposer.getTypeName()}Edge`;
+  const name = `${nodeTypeComposer.getTypeName()}Edge`;
 
-  if (typeComposer.schemaComposer.has(name)) {
-    return typeComposer.schemaComposer.getOTC(name);
+  if (nodeTypeComposer.schemaComposer.has(name)) {
+    return nodeTypeComposer.schemaComposer.getOTC(name);
   }
 
-  const edgeType = typeComposer.schemaComposer.createObjectTC({
+  const edgeType = nodeTypeComposer.schemaComposer.createObjectTC({
     name,
     description: 'An edge in a connection.',
     fields: {
+      ...edgeFields,
       node: {
-        type: new NonNullComposer(typeComposer),
+        type: new NonNullComposer(nodeTypeComposer),
         description: 'The item at the end of the edge',
       },
       cursor: {
@@ -75,7 +78,8 @@ export function prepareEdgeType<TContext>(
 
 export function prepareConnectionType<TContext>(
   typeComposer: ObjectTypeComposer<any, TContext>,
-  resolverName: ?string
+  resolverName: ?string,
+  edgeFields?: ObjectTypeComposerFieldConfigMap<any, TContext>
 ): ObjectTypeComposer<any, TContext> {
   const name = `${typeComposer.getTypeName()}${upperFirst(resolverName || 'connection')}`;
 
@@ -97,7 +101,7 @@ export function prepareConnectionType<TContext>(
       },
       edges: {
         type: new NonNullComposer(
-          new ListComposer(new NonNullComposer(prepareEdgeType(typeComposer)))
+          new ListComposer(new NonNullComposer(prepareEdgeType(typeComposer, edgeFields)))
         ),
         description: 'Information to aid in pagination.',
       },

--- a/src/types/sortInputType.js
+++ b/src/types/sortInputType.js
@@ -6,7 +6,7 @@ import type { ConnectionSortOpts, ComposeWithConnectionOpts } from '../connectio
 
 export function prepareSortType<TContext>(
   typeComposer: ObjectTypeComposer<any, TContext>,
-  opts: ComposeWithConnectionOpts
+  opts: ComposeWithConnectionOpts<TContext>
 ): EnumTypeComposer<TContext> {
   if (!opts || !opts.sort) {
     throw new Error('Option `sort` should not be empty in composeWithConnection');


### PR DESCRIPTION
This PR closes #50 by letting the given `findMany` resolver return not only a `node` but a data structure containing a `node`. See the test for an example of such a resolver.

To really be useful, this also requires a few changes in `graphql-compose-mongoose/resolvers/connection` to support changing the `findManyResolver` and adding `edgeFields`.

What do you think?