### PR TITLE
feat: Add possibility to pass name for connection edge type

### DIFF
--- a/src/connectionResolver.js
+++ b/src/connectionResolver.js
@@ -21,6 +21,7 @@ export type ComposeWithConnectionOpts<TContext> = {
   countResolverName: string,
   sort: ConnectionSortMapOpts,
   defaultLimit?: ?number,
+  edgeTypeName?: string,
   edgeFields?: ObjectTypeComposerFieldConfigMap<any, TContext>,
 };
 
@@ -135,7 +136,12 @@ export function prepareConnectionResolver<TSource, TContext>(
   const defaultValue = firstField && sortEnumType.getField(firstField).value;
 
   return tc.schemaComposer.createResolver({
-    type: prepareConnectionType(tc, opts.connectionResolverName, opts.edgeFields),
+    type: prepareConnectionType(
+      tc,
+      opts.connectionResolverName,
+      opts.edgeTypeName,
+      opts.edgeFields
+    ),
     name: opts.connectionResolverName || 'connection',
     kind: 'query',
     args: {

--- a/src/types/__tests__/connectionType-test.js
+++ b/src/types/__tests__/connectionType-test.js
@@ -41,6 +41,12 @@ describe('types/connectionType.js', () => {
       const t2 = prepareEdgeType(userTC);
       expect(t1).toEqual(t2);
     });
+
+    it('should return different type for same Type in ObjectTypeComposer if passed with different edgeType param', () => {
+      const t1 = prepareEdgeType(userTC);
+      const t2 = prepareEdgeType(userTC, 'UserEdge2');
+      expect(t1).not.toEqual(t2);
+    });
   });
 
   describe('prepareConnectionType()', () => {

--- a/src/types/connectionType.js
+++ b/src/types/connectionType.js
@@ -49,9 +49,10 @@ export function preparePageInfoType(
 
 export function prepareEdgeType<TContext>(
   nodeTypeComposer: ObjectTypeComposer<any, TContext>,
+  edgeTypeName?: string,
   edgeFields?: ObjectTypeComposerFieldConfigMap<any, TContext>
 ): ObjectTypeComposer<any, TContext> {
-  const name = `${nodeTypeComposer.getTypeName()}Edge`;
+  const name = edgeTypeName || `${nodeTypeComposer.getTypeName()}Edge`;
 
   if (nodeTypeComposer.schemaComposer.has(name)) {
     return nodeTypeComposer.schemaComposer.getOTC(name);
@@ -78,7 +79,8 @@ export function prepareEdgeType<TContext>(
 
 export function prepareConnectionType<TContext>(
   typeComposer: ObjectTypeComposer<any, TContext>,
-  resolverName: ?string,
+  resolverName?: string,
+  edgeTypeName?: string,
   edgeFields?: ObjectTypeComposerFieldConfigMap<any, TContext>
 ): ObjectTypeComposer<any, TContext> {
   const name = `${typeComposer.getTypeName()}${upperFirst(resolverName || 'connection')}`;
@@ -101,7 +103,9 @@ export function prepareConnectionType<TContext>(
       },
       edges: {
         type: new NonNullComposer(
-          new ListComposer(new NonNullComposer(prepareEdgeType(typeComposer, edgeFields)))
+          new ListComposer(
+            new NonNullComposer(prepareEdgeType(typeComposer, edgeTypeName, edgeFields))
+          )
         ),
         description: 'Information to aid in pagination.',
       },


### PR DESCRIPTION
This PR closes #52 . Gives the possibility to define the name of the edge type by passing it as an option to `prepareConnectionResolver`. 
