### PR TITLE
fix: remove `edges` field from projection argument provided to `findMany` resolver

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 0,
     '@typescript-eslint/camelcase': 0,
     '@typescript-eslint/ban-ts-comment': 0,
+    '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
   },
   env: {
     jasmine: true,

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   globals: {
     'ts-jest': {
-      tsConfig: '<rootDir>/tsconfig.json',
+      tsconfig: '<rootDir>/tsconfig.json',
       isolatedModules: true,
       diagnostics: false,
     },


### PR DESCRIPTION


relates #75